### PR TITLE
add: 強制アップロードできるように対応

### DIFF
--- a/.github/workflows/chocolatey.yml
+++ b/.github/workflows/chocolatey.yml
@@ -8,6 +8,12 @@ on:
     branches:
       - master
   workflow_dispatch:
+    inputs:
+      force:
+        description: "既存バージョンのチェックをスキップして強制的にビルド・アップロードする"
+        required: false
+        type: boolean
+        default: false
 
 concurrency:
   group: chocolatey-publish
@@ -58,6 +64,13 @@ jobs:
         shell: pwsh
         run: |
           echo "[INFO] Chocolatey に登録済みのバージョンを確認します（審査中を含む）..."
+          $force = "${{ github.event.inputs.force }}"
+          if ($force -eq "true") {
+            echo "[WARN] 強制実行モードが有効です。"
+            echo "[INFO] バージョンチェックをスキップします。"
+            echo "skip=false" >> $env:GITHUB_OUTPUT
+            return
+          }
           $version = "${{ steps.version.outputs.version }}"
           try {
             # OData API で審査中（moderation）のパッケージも含めて全バージョンを取得


### PR DESCRIPTION
<!--
Thank you for contributing to Sakura Internet OSS!
We follow DCO and your commits need to contain `Signed-off-by` line: https://github.com/apps/dco
-->

### どのIssueを閉じますか？

Fixes #

### このPRはどういう変更を行いますか？

- すでにアップロード済みのバージョンでも、強制的に再ビルド＋アップロードできるようにオプションを追加しました。

### ドキュメントの変更は必要ですか？

- なし